### PR TITLE
Fixed https://github.com/martindevans/Cassowary.net/issues/2

### DIFF
--- a/Cassowary/ClLinearExpression.cs
+++ b/Cassowary/ClLinearExpression.cs
@@ -242,9 +242,9 @@ namespace Cassowary
         /// </summary>
         public ClLinearExpression AddVariable(ClAbstractVariable v, double c, ClAbstractVariable subject, ClTableau solver)
         {
-            ClDouble coeff = _terms.ContainsKey(v)?_terms[v]:null;
+            ClDouble coeff;
 
-            if (coeff != null)
+            if (_terms.TryGetValue(v, out coeff) && coeff != null)
             {
                 double newCoefficient = coeff.Value + c;
 
@@ -396,9 +396,9 @@ namespace Cassowary
         public double CoefficientFor(ClAbstractVariable var)
         {
             
-            ClDouble coeff = _terms.ContainsKey(var) ? _terms[var] : null;
+            ClDouble coeff;
 
-            if (coeff != null)
+            if (_terms.TryGetValue(var, out coeff) && coeff != null)
                 return coeff.Value;
             else
                 return 0.0;

--- a/Cassowary/ClLinearExpression.cs
+++ b/Cassowary/ClLinearExpression.cs
@@ -242,7 +242,7 @@ namespace Cassowary
         /// </summary>
         public ClLinearExpression AddVariable(ClAbstractVariable v, double c, ClAbstractVariable subject, ClTableau solver)
         {
-            ClDouble coeff = _terms[v];
+            ClDouble coeff = _terms.ContainsKey(v)?_terms[v]:null;
 
             if (coeff != null)
             {
@@ -395,7 +395,8 @@ namespace Cassowary
         /// </summary>
         public double CoefficientFor(ClAbstractVariable var)
         {
-            ClDouble coeff = _terms[var];
+            
+            ClDouble coeff = _terms.ContainsKey(var) ? _terms[var] : null;
 
             if (coeff != null)
                 return coeff.Value;


### PR DESCRIPTION
Fixed https://github.com/martindevans/Cassowary.net/issues/2

All tests pass.

It should be this way according to the original paper. Not sure why this wasn't like this already. Did the old .net framework version do this implicitly? 

https://constraints.cs.washington.edu/solvers/cassowary-tochi.pdf
Page 34:

>A.2.2 Linear Expressions. Instances of the class ClLinearExpression hold a linear
expression and are used in building and representing constraints and in representing the
tableau. A linear expression holds a dictionary of variables and coefficients (the keys are
variables and the values are the corresponding coefficients). **Only variables with nonzero coefficients are included in the dictionary; if a variable is not in this dictionary its
coefficient is assumed to be zero.**